### PR TITLE
kernel_npem: add support for kernel NPEM driver

### DIFF
--- a/doc/ledmon.conf.pod
+++ b/doc/ledmon.conf.pod
@@ -71,6 +71,12 @@ is set to false - only the drive that the RAID is rebuilding to will be marked
 with appropriate LED pattern. If value is set to true all drives from RAID
 that is during rebuild will blink during this operation.
 
+B<USERSPACE_NPEM> - Use the userspace NPEM controller instead of the controller
+that talks to the kernel NPEM driver. This is useful for kernels that don't
+include the NPEM driver (CONFIG_PCI_NPEM), but it does not work with LED
+control _DSM, and does not work if userspace can't access PCI config space.
+The default value is false.
+
 B<ALLOWLIST> - Ledmon will limit changing LED state to controllers listed on
 allowlist. If any allowlist is set, only devices from the list will be scanned by
 ledmon. The controllers should be separated by a comma (B<,>) character. Only

--- a/src/common/config_file.c
+++ b/src/common/config_file.c
@@ -216,6 +216,11 @@ static int parse_next(FILE *fd, struct ledmon_conf *conf)
 		conf->raid_members_only = parse_bool(s);
 		if (conf->raid_members_only < 0)
 			return -1;
+	} else if (!strncmp(s, "USERSPACE_NPEM=", 15)) {
+		s += 15;
+		conf->userspace_npem = parse_bool(s);
+		if (conf->userspace_npem < 0)
+			return -1;
 	} else if (_parse_and_add_to_list(s, WHITELIST, WHITELIST_LEN, &conf->cntrls_allowlist)) {
 		/* Deprecated, provided for backwards compatibility */
 		return 0;
@@ -329,6 +334,8 @@ int ledmon_write_shared_conf(struct ledmon_conf *conf)
 		 "REBUILD_BLINK_ON_ALL=%d\n", conf->rebuild_blink_on_all);
 	snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf),
 		 "INTERVAL=%d\n", conf->scan_interval);
+	snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf),
+		 "USERSPACE_NPEM=%d\n", conf->userspace_npem);
 	allowlist = conf_list_to_str(&conf->cntrls_allowlist);
 	if (allowlist) {
 		snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf),

--- a/src/common/config_file.h
+++ b/src/common/config_file.h
@@ -35,6 +35,7 @@ struct ledmon_conf {
 	int blink_on_init;
 	int rebuild_blink_on_all;
 	int raid_members_only;
+	int userspace_npem;
 
 	/* allowlist and excludelist of controllers for blinking */
 	struct list cntrls_allowlist;

--- a/src/ledctl/ledctl.c
+++ b/src/ledctl/ledctl.c
@@ -985,8 +985,8 @@ static led_status_t _read_shared_conf(void)
 /**
  * @brief Unset unsupported config parameters.
  *
- * For ledctl only LOG_LEVEL and LOG_PATH are supported and desired.
- * Unset other options.
+ * For ledctl only LOG_LEVEL, LOG_PATH, and USERSPACE_NPEM are supported and
+ * desired. Unset other options.
  */
 static void _unset_unused_options(void)
 {
@@ -1045,6 +1045,8 @@ static led_status_t load_library_prefs(void)
 
 	led_log_fd_set(ctx, get_log_fd(&conf));
 	led_log_level_set(ctx, conf.log_level);
+	if (conf.userspace_npem)
+		use_userspace_npem_controller(ctx);
 	return LED_STATUS_SUCCESS;
 }
 

--- a/src/ledmon/ledmon.c
+++ b/src/ledmon/ledmon.c
@@ -900,6 +900,8 @@ static int load_library_prefs(void)
 
 	led_log_fd_set(ctx, get_log_fd(&conf));
 	led_log_level_set(ctx, conf.log_level);
+	if (conf.userspace_npem)
+		use_userspace_npem_controller(ctx);
 	device_blink_behavior_set(ctx, conf.blink_on_migration, conf.blink_on_init,
 					conf.rebuild_blink_on_all, conf.raid_members_only);
 

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -8,12 +8,12 @@ SUBDIRS = include
 LIB_SRCS         = ahci.c block.c cntrl.c enclosure.c utils.c list.c \
                    raid.c scsi.c tail.c sysfs.c smp.c dellssd.c \
                    pci_slot.c vmdssd.c amd.c amd_sgpio.c amd_ipmi.c\
-                   ipmi.c npem.c ses.c slot.c \
+                   ipmi.c npem.c ses.c slot.c kernel_npem.c\
                    ahci.h amd_sgpio.h block.h cntrl.h dellssd.h utils.h \
                    enclosure.h list.h pci_slot.h raid.h scsi.h \
                    ses.h tail.h smp.h status.h sysfs.h \
                    vmdssd.h ipmi.h amd.h amd_ipmi.h npem.h libled_internal.c \
-		   slot.h libled_private.h libled_internal.h
+		   kernel_npem.h slot.h libled_private.h libled_internal.h
 
 # Make a convenience library, to be used for led tools and the shared library
 noinst_LTLIBRARIES = libledinternal.la

--- a/src/lib/block.c
+++ b/src/lib/block.c
@@ -19,6 +19,7 @@
 #include "block.h"
 #include "config.h"
 #include "dellssd.h"
+#include "kernel_npem.h"
 #include "libled_private.h"
 #include "npem.h"
 #include "pci_slot.h"
@@ -75,6 +76,9 @@ static void _set_send_message_fn(struct block_device *device)
 			device->send_message_fn = scsi_smp_fill_buffer;
 		else
 			device->send_message_fn = scsi_ses_write;
+		break;
+	case LED_CNTRL_TYPE_KERNEL_NPEM:
+		device->send_message_fn = kernel_npem_write;
 		break;
 	case LED_CNTRL_TYPE_DELLSSD:
 		device->send_message_fn = dellssd_write;
@@ -137,6 +141,8 @@ static char *_get_host(char *path, struct cntrl_device *cntrl)
 		result = scsi_get_host_path(path, cntrl->sysfs_path);
 	else if (cntrl->cntrl_type == LED_CNTRL_TYPE_AHCI)
 		result = ahci_get_port_path(path);
+	else if (cntrl->cntrl_type == LED_CNTRL_TYPE_KERNEL_NPEM)
+		result = kernel_npem_get_path(cntrl->sysfs_path);
 	else if (cntrl->cntrl_type == LED_CNTRL_TYPE_DELLSSD)
 		result = dellssd_get_path(cntrl->sysfs_path);
 	else if (cntrl->cntrl_type == LED_CNTRL_TYPE_VMD)

--- a/src/lib/block.c
+++ b/src/lib/block.c
@@ -164,6 +164,7 @@ static int is_host_id_supported(const struct block_device *bd)
 	case LED_CNTRL_TYPE_DELLSSD:
 	case LED_CNTRL_TYPE_VMD:
 	case LED_CNTRL_TYPE_NPEM:
+	case LED_CNTRL_TYPE_KERNEL_NPEM:
 		return 0;
 	default:
 		return 1;
@@ -194,7 +195,8 @@ struct cntrl_device *block_get_controller(const struct list *cntrl_list, char *p
 		if (cntrl) {
 			if (strncmp(cntrl->sysfs_path, path,
 				strnlen(cntrl->sysfs_path, PATH_MAX)) == 0) {
-				if (cntrl->cntrl_type == LED_CNTRL_TYPE_NPEM)
+				if ((cntrl->cntrl_type == LED_CNTRL_TYPE_NPEM) ||
+				    (cntrl->cntrl_type == LED_CNTRL_TYPE_KERNEL_NPEM))
 					return cntrl;
 				non_npem_cntrl = cntrl;
 			}

--- a/src/lib/block.c
+++ b/src/lib/block.c
@@ -77,9 +77,6 @@ static void _set_send_message_fn(struct block_device *device)
 		else
 			device->send_message_fn = scsi_ses_write;
 		break;
-	case LED_CNTRL_TYPE_KERNEL_NPEM:
-		device->send_message_fn = kernel_npem_write;
-		break;
 	case LED_CNTRL_TYPE_DELLSSD:
 		device->send_message_fn = dellssd_write;
 		break;
@@ -87,7 +84,10 @@ static void _set_send_message_fn(struct block_device *device)
 		device->send_message_fn = vmdssd_write;
 		break;
 	case LED_CNTRL_TYPE_NPEM:
-		device->send_message_fn = npem_write;
+		if (device->cntrl->ctx->config.userspace_npem)
+			device->send_message_fn = npem_write;
+		else
+			device->send_message_fn = kernel_npem_write;
 		break;
 	case LED_CNTRL_TYPE_AMD:
 		device->send_message_fn = amd_write;
@@ -141,14 +141,15 @@ static char *_get_host(char *path, struct cntrl_device *cntrl)
 		result = scsi_get_host_path(path, cntrl->sysfs_path);
 	else if (cntrl->cntrl_type == LED_CNTRL_TYPE_AHCI)
 		result = ahci_get_port_path(path);
-	else if (cntrl->cntrl_type == LED_CNTRL_TYPE_KERNEL_NPEM)
-		result = kernel_npem_get_path(cntrl->sysfs_path);
-	else if (cntrl->cntrl_type == LED_CNTRL_TYPE_DELLSSD)
+	else if (cntrl->cntrl_type == LED_CNTRL_TYPE_NPEM) {
+		if (cntrl->ctx->config.userspace_npem)
+			result = npem_get_path(cntrl->sysfs_path);
+		else
+			result = kernel_npem_get_path(cntrl->sysfs_path);
+	} else if (cntrl->cntrl_type == LED_CNTRL_TYPE_DELLSSD)
 		result = dellssd_get_path(cntrl->sysfs_path);
 	else if (cntrl->cntrl_type == LED_CNTRL_TYPE_VMD)
 		result = vmdssd_get_path(cntrl->sysfs_path);
-	else if (cntrl->cntrl_type == LED_CNTRL_TYPE_NPEM)
-		result = npem_get_path(cntrl->sysfs_path);
 	else if (cntrl->cntrl_type == LED_CNTRL_TYPE_AMD)
 		result = amd_get_path(path, cntrl->sysfs_path, cntrl->ctx);
 
@@ -164,7 +165,6 @@ static int is_host_id_supported(const struct block_device *bd)
 	case LED_CNTRL_TYPE_DELLSSD:
 	case LED_CNTRL_TYPE_VMD:
 	case LED_CNTRL_TYPE_NPEM:
-	case LED_CNTRL_TYPE_KERNEL_NPEM:
 		return 0;
 	default:
 		return 1;
@@ -195,8 +195,7 @@ struct cntrl_device *block_get_controller(const struct list *cntrl_list, char *p
 		if (cntrl) {
 			if (strncmp(cntrl->sysfs_path, path,
 				strnlen(cntrl->sysfs_path, PATH_MAX)) == 0) {
-				if ((cntrl->cntrl_type == LED_CNTRL_TYPE_NPEM) ||
-				    (cntrl->cntrl_type == LED_CNTRL_TYPE_KERNEL_NPEM))
+				if (cntrl->cntrl_type == LED_CNTRL_TYPE_NPEM)
 					return cntrl;
 				non_npem_cntrl = cntrl;
 			}

--- a/src/lib/cntrl.c
+++ b/src/lib/cntrl.c
@@ -16,6 +16,7 @@
 #include "amd.h"
 #include "cntrl.h"
 #include "config.h"
+#include "kernel_npem.h"
 #include "list.h"
 #include "libled_private.h"
 #include "npem.h"
@@ -179,6 +180,10 @@ static int _is_npem_cntrl(const char *path, struct led_ctx *ctx)
 	return is_npem_capable(path, ctx);
 }
 
+static int _is_kernel_npem_cntrl(const char *path)
+{
+	return is_kernel_npem_present(path);
+}
 /**
  * @brief Determines the type of controller.
  *
@@ -200,6 +205,8 @@ static enum led_cntrl_type _get_type(const char *path, struct led_ctx *ctx)
 		type = LED_CNTRL_TYPE_NPEM;
 	} else if (_is_vmd_cntrl(path)) {
 		type = LED_CNTRL_TYPE_VMD;
+	} else if (_is_kernel_npem_cntrl(path)) {
+		type = LED_CNTRL_TYPE_KERNEL_NPEM;
 	} else if (_is_dellssd_cntrl(path, ctx)) {
 		type = LED_CNTRL_TYPE_DELLSSD;
 	} else if (_is_storage_controller(path)) {
@@ -400,6 +407,7 @@ struct cntrl_device *cntrl_device_init(const char *path, struct led_ctx *ctx)
 		case LED_CNTRL_TYPE_SCSI:
 		case LED_CNTRL_TYPE_VMD:
 		case LED_CNTRL_TYPE_NPEM:
+		case LED_CNTRL_TYPE_KERNEL_NPEM:
 			em_enabled = 1;
 			break;
 		case LED_CNTRL_TYPE_AHCI:

--- a/src/lib/cntrl.c
+++ b/src/lib/cntrl.c
@@ -177,13 +177,12 @@ static int _is_vmd_cntrl(const char *path)
 
 static int _is_npem_cntrl(const char *path, struct led_ctx *ctx)
 {
-	return is_npem_capable(path, ctx);
+	if (ctx->config.userspace_npem)
+		return is_npem_capable(path, ctx);
+	else
+		return is_kernel_npem_present(path);
 }
 
-static int _is_kernel_npem_cntrl(const char *path)
-{
-	return is_kernel_npem_present(path);
-}
 /**
  * @brief Determines the type of controller.
  *
@@ -205,8 +204,6 @@ static enum led_cntrl_type _get_type(const char *path, struct led_ctx *ctx)
 		type = LED_CNTRL_TYPE_NPEM;
 	} else if (_is_vmd_cntrl(path)) {
 		type = LED_CNTRL_TYPE_VMD;
-	} else if (_is_kernel_npem_cntrl(path)) {
-		type = LED_CNTRL_TYPE_KERNEL_NPEM;
 	} else if (_is_dellssd_cntrl(path, ctx)) {
 		type = LED_CNTRL_TYPE_DELLSSD;
 	} else if (_is_storage_controller(path)) {
@@ -407,7 +404,6 @@ struct cntrl_device *cntrl_device_init(const char *path, struct led_ctx *ctx)
 		case LED_CNTRL_TYPE_SCSI:
 		case LED_CNTRL_TYPE_VMD:
 		case LED_CNTRL_TYPE_NPEM:
-		case LED_CNTRL_TYPE_KERNEL_NPEM:
 			em_enabled = 1;
 			break;
 		case LED_CNTRL_TYPE_AHCI:

--- a/src/lib/include/led/libled.h
+++ b/src/lib/include/led/libled.h
@@ -36,6 +36,7 @@ enum led_cntrl_type {
 	LED_CNTRL_TYPE_AHCI = 4,
 	LED_CNTRL_TYPE_NPEM = 5,
 	LED_CNTRL_TYPE_AMD = 6,
+	LED_CNTRL_TYPE_KERNEL_NPEM = 7,
 };
 
 /**

--- a/src/lib/include/led/libled.h
+++ b/src/lib/include/led/libled.h
@@ -36,7 +36,6 @@ enum led_cntrl_type {
 	LED_CNTRL_TYPE_AHCI = 4,
 	LED_CNTRL_TYPE_NPEM = 5,
 	LED_CNTRL_TYPE_AMD = 6,
-	LED_CNTRL_TYPE_KERNEL_NPEM = 7,
 };
 
 /**
@@ -271,6 +270,16 @@ void LED_SYM_PUBLIC led_log_fd_set(struct led_ctx *ctx, int log_fd);
  *  - You must set a valid open file descriptor before any log messages will be written.
  */
 void LED_SYM_PUBLIC led_log_level_set(struct led_ctx *ctx, enum led_log_level_enum level);
+
+/**
+ * @brief Set use of userspace NPEM controller (instead of kernel NPEM controller).
+ *
+ * @param[in]	ctx	Library context
+ *
+ * Notes:
+ *  - The kernel NPEM controller will be used unless this is called.
+ */
+void LED_SYM_PUBLIC use_userspace_npem_controller(struct led_ctx *ctx);
 
 /**
  * @brief Instructs the library to scan system hardware for block devices with LED support.

--- a/src/lib/kernel_npem.c
+++ b/src/lib/kernel_npem.c
@@ -105,9 +105,8 @@ static u32 kernel_npem_supported_mask(const char *sysfs_path)
 	char led_path[PATH_MAX];
 	int i;
 	struct stat sb;
-	u32 supported;
+	u32 supported = 0;
 
-	supported = 0;
 	for (i = 0; i < ARRAY_SIZE(kernel_npem_leds); i++) {
 		make_led_path(led_path, sysfs_path, kernel_npem_leds[i].sysfs_led_name);
 		if (!stat(led_path, &sb))

--- a/src/lib/kernel_npem.c
+++ b/src/lib/kernel_npem.c
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2022 Intel Corporation.
+// Copyright (C) 2025 Dell Inc.
+
+/* System headers */
+#include <stdio.h>
+#include <string.h>
+#include <pci/pci.h>
+#include <time.h>
+#include <stdbool.h>
+#include <sys/stat.h>
+
+/* Local headers */
+#include "libled_private.h"
+#include "cntrl.h"
+#include "npem.h"
+#include "utils.h"
+
+/* NPEM OK Capable/Control */
+#define PCI_NPEM_OK_CAP		0x004
+/* NPEM Locate Capable/Control */
+#define PCI_NPEM_LOCATE_CAP	0x008
+/* NPEM Fail Capable/Control */
+#define PCI_NPEM_FAIL_CAP	0x010
+/* NPEM Rebuild Capable/Control */
+#define PCI_NPEM_REBUILD_CAP	0x020
+/* NPEM Predicted Failure Analysis Capable/Control */
+#define PCI_NPEM_PFA_CAP	0x040
+/* NPEM Hot Spare Capable/Control */
+#define PCI_NPEM_HOT_SPARE_CAP	0x080
+/* NPEM in a Critical Array Capable/Control */
+#define PCI_NPEM_CRA_CAP	0x100
+/* NPEM in a Failed Array Capable/Control */
+#define PCI_NPEM_FA_CAP		0x200
+
+static const struct ibpi2value ibpi_to_npem_capability[] = {
+	{LED_IBPI_PATTERN_NORMAL, PCI_NPEM_OK_CAP},
+	{LED_IBPI_PATTERN_ONESHOT_NORMAL, PCI_NPEM_OK_CAP},
+	{LED_IBPI_PATTERN_DEGRADED, PCI_NPEM_CRA_CAP},
+	{LED_IBPI_PATTERN_HOTSPARE, PCI_NPEM_HOT_SPARE_CAP},
+	{LED_IBPI_PATTERN_REBUILD, PCI_NPEM_REBUILD_CAP},
+	{LED_IBPI_PATTERN_FAILED_ARRAY, PCI_NPEM_FA_CAP},
+	{LED_IBPI_PATTERN_PFA, PCI_NPEM_PFA_CAP},
+	{LED_IBPI_PATTERN_FAILED_DRIVE, PCI_NPEM_FAIL_CAP},
+	{LED_IBPI_PATTERN_LOCATE, PCI_NPEM_LOCATE_CAP},
+	{LED_IBPI_PATTERN_LOCATE_OFF, PCI_NPEM_OK_CAP},
+	{LED_IBPI_PATTERN_UNKNOWN, 0}
+};
+
+struct kernel_npem_led {
+	int	bitmask;
+	char	*sysfs_led_name;
+};
+
+const struct kernel_npem_led kernel_npem_leds[] = {
+	{PCI_NPEM_OK_CAP, "enclosure:ok"},
+	{PCI_NPEM_LOCATE_CAP, "enclosure:locate"},
+	{PCI_NPEM_FAIL_CAP, "enclosure:fail"},
+	{PCI_NPEM_REBUILD_CAP, "enclosure:rebuild"},
+	{PCI_NPEM_PFA_CAP, "enclosure:pfa"},
+	{PCI_NPEM_HOT_SPARE_CAP, "enclosure:hotspare"},
+	{PCI_NPEM_CRA_CAP, "enclosure:ica"},
+	{PCI_NPEM_FA_CAP, "enclosure:ifa"},
+};
+
+char *kernel_npem_get_path(const char *cntrl_path)
+{
+	return strdup(cntrl_path);
+}
+
+#define make_led_path(sysfs_led_path, sysfs_path, sysfs_led_name) \
+	snprintf(sysfs_led_path, sizeof(sysfs_led_path), "%s/leds/%s:%s/brightness", \
+		 sysfs_path, basename(sysfs_path), sysfs_led_name)
+
+static u32 read_kernel_npem_register(const char *sysfs_path)
+{
+	char led_path[PATH_MAX];
+	int i;
+	u32 reg = 0;
+
+	for (i = 0; i < ARRAY_SIZE(kernel_npem_leds); i++) {
+		make_led_path(led_path, sysfs_path, kernel_npem_leds[i].sysfs_led_name);
+		reg |= get_int("/", 0, led_path) ? kernel_npem_leds[i].bitmask : 0;
+	}
+	return reg;
+}
+
+static int write_kernel_npem_register(const char *sysfs_path, u32 val)
+{
+	char led_path[PATH_MAX], val_text[4];
+	int i;
+	struct stat sb;
+
+	for (i = 0; i < ARRAY_SIZE(kernel_npem_leds); i++) {
+		make_led_path(led_path, sysfs_path, kernel_npem_leds[i].sysfs_led_name);
+		snprintf(val_text, sizeof(val_text), val & kernel_npem_leds[i].bitmask ? "1" : "0");
+		if (!stat(led_path, &sb))
+			buf_write(led_path, val_text);
+	}
+	return 0;
+}
+
+static u32 kernel_npem_supported_mask(const char *sysfs_path)
+{
+	char led_path[PATH_MAX];
+	int i;
+	struct stat sb;
+	u32 supported;
+
+	supported = 0;
+	for (i = 0; i < ARRAY_SIZE(kernel_npem_leds); i++) {
+		make_led_path(led_path, sysfs_path, kernel_npem_leds[i].sysfs_led_name);
+		if (!stat(led_path, &sb))
+			supported |= kernel_npem_leds[i].bitmask;
+	}
+	return supported;
+}
+
+int is_kernel_npem_present(const char *path)
+{
+	return kernel_npem_supported_mask(path) ? 1 : 0;
+}
+
+enum led_ibpi_pattern kernel_npem_get_state(struct slot_property *slot)
+{
+	const char *path = slot->slot_spec.cntrl->sysfs_path;
+	const struct ibpi2value *ibpi2val;
+	u32 reg;
+
+	reg = read_kernel_npem_register(path);
+	ibpi2val =  get_by_bits(reg, ibpi_to_npem_capability,
+				ARRAY_SIZE(ibpi_to_npem_capability));
+
+	return ibpi2val->ibpi;
+}
+
+status_t kernel_npem_set_slot(struct led_ctx *ctx, const char *sysfs_path,
+			      enum led_ibpi_pattern state)
+{
+	const struct ibpi2value *ibpi2val;
+	u32 requested, supported;
+
+	ibpi2val = get_by_ibpi(state, ibpi_to_npem_capability,
+			       ARRAY_SIZE(ibpi_to_npem_capability));
+
+	if (ibpi2val->ibpi == LED_IBPI_PATTERN_UNKNOWN) {
+		lib_log(ctx, LED_LOG_LEVEL_INFO,
+			"KERNEL_NPEM: Controller doesn't support %s pattern\n", ibpi2str(state));
+		return STATUS_INVALID_STATE;
+	}
+
+	requested = (u32)ibpi2val->value;
+	supported = kernel_npem_supported_mask(sysfs_path);
+
+	if (!(requested & supported))
+		/*
+		 * Allow OK (normal and locate_off states) to turn off other
+		 * states even if OK state isn't actually supported.
+		 */
+		if (requested != PCI_NPEM_OK_CAP) {
+			lib_log(ctx, LED_LOG_LEVEL_INFO,
+				"KERNEL_NPEM: Controller %s doesn't support %s pattern\n",
+				sysfs_path, ibpi2str(state));
+			return STATUS_INVALID_STATE;
+		}
+
+	write_kernel_npem_register(sysfs_path, requested);
+
+	return STATUS_SUCCESS;
+}
+
+status_t kernel_npem_set_state(struct slot_property *slot, enum led_ibpi_pattern state)
+{
+	return kernel_npem_set_slot(slot->slot_spec.cntrl->ctx,
+				    slot->slot_spec.cntrl->sysfs_path, state);
+}
+
+const struct slot_property_common kernel_npem_slot_common = {
+	.cntrl_type = LED_CNTRL_TYPE_KERNEL_NPEM,
+	.get_state_fn = kernel_npem_get_state,
+	.set_slot_fn = kernel_npem_set_state,
+};
+
+struct slot_property *kernel_npem_slot_property_init(struct cntrl_device *kernel_npem_cntrl)
+{
+	struct slot_property *result = calloc(1, sizeof(struct slot_property));
+
+	if (result == NULL)
+		return NULL;
+
+	result->bl_device = get_block_device_from_sysfs_path(kernel_npem_cntrl->ctx,
+							     kernel_npem_cntrl->sysfs_path, true);
+	result->slot_spec.cntrl = kernel_npem_cntrl;
+	snprintf(result->slot_id, PATH_MAX, "%s", kernel_npem_cntrl->sysfs_path);
+	result->c = &kernel_npem_slot_common;
+	return result;
+}
+
+status_t kernel_npem_write(struct block_device *device, enum led_ibpi_pattern ibpi)
+{
+	if (ibpi < LED_IBPI_PATTERN_NORMAL || ibpi > LED_IBPI_PATTERN_LOCATE_OFF)
+		return STATUS_INVALID_STATE;
+
+	return kernel_npem_set_slot(device->cntrl->ctx, device->cntrl->sysfs_path, ibpi);
+}

--- a/src/lib/kernel_npem.c
+++ b/src/lib/kernel_npem.c
@@ -152,7 +152,7 @@ status_t kernel_npem_set_slot(struct led_ctx *ctx, const char *sysfs_path,
 
 	if (ibpi2val->ibpi == LED_IBPI_PATTERN_UNKNOWN) {
 		lib_log(ctx, LED_LOG_LEVEL_INFO,
-			"KERNEL_NPEM: Controller doesn't support %s pattern\n", ibpi2str(state));
+			"NPEM: Controller doesn't support %s pattern\n", ibpi2str(state));
 		return STATUS_INVALID_STATE;
 	}
 
@@ -166,7 +166,7 @@ status_t kernel_npem_set_slot(struct led_ctx *ctx, const char *sysfs_path,
 		 */
 		if (requested != PCI_NPEM_OK_CAP) {
 			lib_log(ctx, LED_LOG_LEVEL_INFO,
-				"KERNEL_NPEM: Controller %s doesn't support %s pattern\n",
+				"NPEM: Controller %s doesn't support %s pattern\n",
 				sysfs_path, ibpi2str(state));
 			return STATUS_INVALID_STATE;
 		}
@@ -183,7 +183,7 @@ status_t kernel_npem_set_state(struct slot_property *slot, enum led_ibpi_pattern
 }
 
 const struct slot_property_common kernel_npem_slot_common = {
-	.cntrl_type = LED_CNTRL_TYPE_KERNEL_NPEM,
+	.cntrl_type = LED_CNTRL_TYPE_NPEM,
 	.get_state_fn = kernel_npem_get_state,
 	.set_slot_fn = kernel_npem_set_state,
 };

--- a/src/lib/kernel_npem.c
+++ b/src/lib/kernel_npem.c
@@ -130,6 +130,14 @@ enum led_ibpi_pattern kernel_npem_get_state(struct slot_property *slot)
 	ibpi2val =  get_by_bits(reg, ibpi_to_npem_capability,
 				ARRAY_SIZE(ibpi_to_npem_capability));
 
+       /*
+        * If LOCATE is the only pattern supported, report LOCATE_OFF instead
+        * of UNKNOWN.
+        */
+       if ((ibpi2val->ibpi == LED_IBPI_PATTERN_UNKNOWN) &&
+           (kernel_npem_supported_mask(path) == PCI_NPEM_LOCATE_CAP))
+                       return LED_IBPI_PATTERN_LOCATE_OFF;
+
 	return ibpi2val->ibpi;
 }
 

--- a/src/lib/kernel_npem.h
+++ b/src/lib/kernel_npem.h
@@ -43,7 +43,7 @@ enum led_ibpi_pattern kernel_npem_get_state(struct slot_property *slot);
 status_t kernel_npem_set_state(struct slot_property *slot, enum led_ibpi_pattern state);
 
 /**
- * @brief Initializes a slot_property for a specified npem controller.
+ * @brief Initializes a slot_property for a specified NPEM controller.
  *
  * @param[in]         npem_cntrl       Specified npem controller for this slot
  * @return struct slot_property* if successful, else NULL on allocation failure

--- a/src/lib/kernel_npem.h
+++ b/src/lib/kernel_npem.h
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2022 Intel Corporation.
+// Copyright (C) 2025 Dell Inc.
+
+#ifndef _KERNEL_NPEM_H_INCLUDED_
+#define _KERNEL_NPEM_H_INCLUDED_
+
+/* Project headers */
+#include <led/libled.h>
+
+/* Local headers */
+#include "block.h"
+#include "cntrl.h"
+#include "slot.h"
+#include "status.h"
+
+
+int is_kernel_npem_present(const char *path);
+status_t kernel_npem_write(struct block_device *device, enum led_ibpi_pattern ibpi);
+char *kernel_npem_get_path(const char *cntrl_path);
+
+/**
+ * @brief Gets slot information.
+ *
+ * This function fills slot information related to the slot.
+ *
+ * @param[in]         slot       Pointer to the slot property element.
+ *
+ * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
+ */
+enum led_ibpi_pattern kernel_npem_get_state(struct slot_property *slot);
+
+/**
+ * @brief Sets led state for slot.
+ *
+ * This function sets given led state for slot.
+ *
+ * @param[in]         slot           Requested slot.
+ * @param[in]         state          IBPI state based on slot request.
+ *
+ * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
+ */
+status_t kernel_npem_set_state(struct slot_property *slot, enum led_ibpi_pattern state);
+
+/**
+ * @brief Initializes a slot_property for a specified npem controller.
+ *
+ * @param[in]         npem_cntrl       Specified npem controller for this slot
+ * @return struct slot_property* if successful, else NULL on allocation failure
+ */
+struct slot_property *kernel_npem_slot_property_init(struct cntrl_device *npem_cntrl);
+
+#endif // _KERNEL_NPEM_H_INCLUDED_

--- a/src/lib/libled.c
+++ b/src/lib/libled.c
@@ -311,6 +311,7 @@ static const char * const ctrl_type_str[] = {
 	[LED_CNTRL_TYPE_AHCI]    = "AHCI",
 	[LED_CNTRL_TYPE_NPEM]    = "NPEM",
 	[LED_CNTRL_TYPE_AMD]     = "AMD",
+	[LED_CNTRL_TYPE_KERNEL_NPEM]     = "Kernel NPEM",
 };
 
 enum led_cntrl_type led_string_to_cntrl_type(const char *cntrl_str)

--- a/src/lib/libled.c
+++ b/src/lib/libled.c
@@ -230,7 +230,8 @@ led_status_t led_slot_set(struct led_ctx *ctx, struct led_slot_list_entry *se,
 bool led_controller_slot_support(enum led_cntrl_type cntrl)
 {
 	return (cntrl == LED_CNTRL_TYPE_NPEM || cntrl == LED_CNTRL_TYPE_SCSI ||
-		cntrl == LED_CNTRL_TYPE_VMD);
+		cntrl == LED_CNTRL_TYPE_VMD) ||
+		cntrl == LED_CNTRL_TYPE_KERNEL_NPEM;
 }
 
 struct led_slot_list_entry *led_slot_next(struct led_slot_list *sl)

--- a/src/lib/libled.c
+++ b/src/lib/libled.c
@@ -66,6 +66,11 @@ void led_log_level_set(struct led_ctx *ctx, enum led_log_level_enum level)
 	ctx->log_lvl = level;
 }
 
+void use_userspace_npem_controller(struct led_ctx *ctx)
+{
+	ctx->config.userspace_npem = 1;
+}
+
 led_status_t led_scan(struct led_ctx *ctx)
 {
 	if (!ctx)
@@ -230,8 +235,7 @@ led_status_t led_slot_set(struct led_ctx *ctx, struct led_slot_list_entry *se,
 bool led_controller_slot_support(enum led_cntrl_type cntrl)
 {
 	return (cntrl == LED_CNTRL_TYPE_NPEM || cntrl == LED_CNTRL_TYPE_SCSI ||
-		cntrl == LED_CNTRL_TYPE_VMD) ||
-		cntrl == LED_CNTRL_TYPE_KERNEL_NPEM;
+		cntrl == LED_CNTRL_TYPE_VMD);
 }
 
 struct led_slot_list_entry *led_slot_next(struct led_slot_list *sl)
@@ -312,7 +316,6 @@ static const char * const ctrl_type_str[] = {
 	[LED_CNTRL_TYPE_AHCI]    = "AHCI",
 	[LED_CNTRL_TYPE_NPEM]    = "NPEM",
 	[LED_CNTRL_TYPE_AMD]     = "AMD",
-	[LED_CNTRL_TYPE_KERNEL_NPEM]     = "Kernel NPEM",
 };
 
 enum led_cntrl_type led_string_to_cntrl_type(const char *cntrl_str)

--- a/src/lib/libled_private.h
+++ b/src/lib/libled_private.h
@@ -35,6 +35,7 @@ struct configuration {
 	int blink_on_init;
 	int rebuild_blink_on_all;
 	int raid_members_only;
+	int userspace_npem;
 
 	struct list allowlist;
 	struct list excludelist;

--- a/src/lib/sysfs.c
+++ b/src/lib/sysfs.c
@@ -20,6 +20,7 @@
 #include "config.h"
 #include "cntrl.h"
 #include "enclosure.h"
+#include "kernel_npem.h"
 #include "list.h"
 #include "libled_private.h"
 #include "npem.h"
@@ -410,6 +411,11 @@ static void _scan_slots(struct led_ctx *ctx)
 	list_for_each(sysfs_get_cntrl_devices(ctx), cntrl_device) {
 		if (cntrl_device->cntrl_type == LED_CNTRL_TYPE_NPEM) {
 			slot = npem_slot_property_init(cntrl_device);
+			if (slot)
+				list_append_ctx(&ctx->sys.slots_list, slot, ctx);
+		}
+		if (cntrl_device->cntrl_type == LED_CNTRL_TYPE_KERNEL_NPEM) {
+			slot = kernel_npem_slot_property_init(cntrl_device);
 			if (slot)
 				list_append_ctx(&ctx->sys.slots_list, slot, ctx);
 		}

--- a/src/lib/sysfs.c
+++ b/src/lib/sysfs.c
@@ -413,8 +413,7 @@ static void _scan_slots(struct led_ctx *ctx)
 			slot = npem_slot_property_init(cntrl_device);
 			if (slot)
 				list_append_ctx(&ctx->sys.slots_list, slot, ctx);
-		}
-		if (cntrl_device->cntrl_type == LED_CNTRL_TYPE_KERNEL_NPEM) {
+		} else if (cntrl_device->cntrl_type == LED_CNTRL_TYPE_KERNEL_NPEM) {
 			slot = kernel_npem_slot_property_init(cntrl_device);
 			if (slot)
 				list_append_ctx(&ctx->sys.slots_list, slot, ctx);

--- a/src/lib/sysfs.c
+++ b/src/lib/sysfs.c
@@ -410,11 +410,10 @@ static void _scan_slots(struct led_ctx *ctx)
 
 	list_for_each(sysfs_get_cntrl_devices(ctx), cntrl_device) {
 		if (cntrl_device->cntrl_type == LED_CNTRL_TYPE_NPEM) {
-			slot = npem_slot_property_init(cntrl_device);
-			if (slot)
-				list_append_ctx(&ctx->sys.slots_list, slot, ctx);
-		} else if (cntrl_device->cntrl_type == LED_CNTRL_TYPE_KERNEL_NPEM) {
-			slot = kernel_npem_slot_property_init(cntrl_device);
+			if (ctx->config.userspace_npem)
+				slot = npem_slot_property_init(cntrl_device);
+			else
+				slot = kernel_npem_slot_property_init(cntrl_device);
 			if (slot)
 				list_append_ctx(&ctx->sys.slots_list, slot, ctx);
 		}

--- a/tests/lib_unit_test.c
+++ b/tests/lib_unit_test.c
@@ -144,7 +144,7 @@ START_TEST(test_list_controllers)
 			enum led_cntrl_type t = led_cntrl_type(ce);
 
 			devices_found = true;
-			ck_assert_msg(((int)t >= 1 && (int)t <= 6),  "invalid %u cntrl type", t);
+			ck_assert_msg(((int)t >= 1 && (int)t <= 7),  "invalid %u cntrl type", t);
 		}
 
 		led_cntrl_list_reset(cl);
@@ -152,7 +152,7 @@ START_TEST(test_list_controllers)
 			ck_assert_msg(led_cntrl_path(ce) != NULL, "led_cntrl_path returned NULL");
 			enum led_cntrl_type t = led_cntrl_type(ce);
 
-			ck_assert_msg(((int)t >= 1 && (int)t <= 6),  "invalid %u cntrl type", t);
+			ck_assert_msg(((int)t >= 1 && (int)t <= 7),  "invalid %u cntrl type", t);
 		}
 
 		led_cntrl_list_free(cl);
@@ -177,7 +177,7 @@ START_TEST(test_list_slots)
 			ck_assert_msg(led_slot_id(se) != NULL, "led_slot_id returned NULL");
 			enum led_cntrl_type t = led_slot_cntrl(se);
 
-			ck_assert_msg(((int)t >= 1 && (int)t <= 6),  "invalid %u cntrl type", t);
+			ck_assert_msg(((int)t >= 1 && (int)t <= 7),  "invalid %u cntrl type", t);
 			devices_found = true;
 			// TODO: Check led ibpi pattern and validate
 
@@ -189,7 +189,7 @@ START_TEST(test_list_slots)
 			ck_assert_msg(led_slot_id(se) != NULL, "led_slot_id returned NULL");
 			enum led_cntrl_type t = led_slot_cntrl(se);
 
-			ck_assert_msg(((int)t >= 1 && (int)t <= 6),  "invalid %u cntrl type", t);
+			ck_assert_msg(((int)t >= 1 && (int)t <= 7),  "invalid %u cntrl type", t);
 			// TODO: Check led ibpi pattern and validate
 
 			block_device_check(led_slot_device(se));


### PR DESCRIPTION
Add a new controller for the recently-added kernel NPEM/_DSM driver (in the kernel at drivers/pci/npem.c) that provides access to NPEM LEDs via sysfs. This allows access even if the kernel doesn't allow direct access to PCI config space (for NPEM), and also allows access to the PCI _DSM method of controlling PCIe SSD LEDs (PCI Firmware Specification, Revision 3.3, section 4.7 "_DSM Definitions for PCIe SSD Status LED").

The code was based on the npem controller code, but uses the sysfs interface rather than directly accessing the NPEM capability in PCI config space.