### PR TITLE
Fix NVMe hot-swap LED stuck in FAILURE under VMD controllers

### DIFF
--- a/doc/ledmon.conf.pod
+++ b/doc/ledmon.conf.pod
@@ -63,6 +63,14 @@ Value also can be set by integer number - 0 means 'quiet' and 5 means 'all'.
 B<LOG_PATH> - Sets a path to local log file. If this option is specified the
 global log file F</var/log/ledmon.log> is not used.
 
+B<BLINK_PERSISTENT_FAIL_ON_READD> - Controls whether the failure LED remains
+on when a non-RAID drive is re-added after removal. If value is set to true,
+the failure indication persists until the drive is manually addressed. If value
+is set to false, non-RAID drives that reappear in the sysfs scan will
+automatically recover from the failure state and the LED will be cleared. RAID
+member drives always retain persistent failure regardless of this setting. The
+default value is true.
+
 B<RAID_MEMBERS_ONLY> - If flag is set to true ledmon will limit monitoring only
 to drives that are RAID members. The default value is false.
 

--- a/src/common/config_file.c
+++ b/src/common/config_file.c
@@ -216,6 +216,11 @@ static int parse_next(FILE *fd, struct ledmon_conf *conf)
 		conf->raid_members_only = parse_bool(s);
 		if (conf->raid_members_only < 0)
 			return -1;
+	} else if (!strncmp(s, "BLINK_PERSISTENT_FAIL_ON_READD=", 31)) {
+		s += 31;
+		conf->blink_persistent_fail_on_readd = parse_bool(s);
+		if (conf->blink_persistent_fail_on_readd < 0)
+			return -1;
 	} else if (_parse_and_add_to_list(s, WHITELIST, WHITELIST_LEN, &conf->cntrls_allowlist)) {
 		/* Deprecated, provided for backwards compatibility */
 		return 0;
@@ -327,6 +332,9 @@ int ledmon_write_shared_conf(struct ledmon_conf *conf)
 		 "RAID_MEMBERS_ONLY=%d\n", conf->raid_members_only);
 	snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf),
 		 "REBUILD_BLINK_ON_ALL=%d\n", conf->rebuild_blink_on_all);
+	snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf),
+		 "BLINK_PERSISTENT_FAIL_ON_READD=%d\n",
+		 conf->blink_persistent_fail_on_readd);
 	snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf),
 		 "INTERVAL=%d\n", conf->scan_interval);
 	allowlist = conf_list_to_str(&conf->cntrls_allowlist);

--- a/src/common/config_file.h
+++ b/src/common/config_file.h
@@ -35,6 +35,7 @@ struct ledmon_conf {
 	int blink_on_init;
 	int rebuild_blink_on_all;
 	int raid_members_only;
+	int blink_persistent_fail_on_readd;
 
 	/* allowlist and excludelist of controllers for blinking */
 	struct list cntrls_allowlist;

--- a/src/ledmon/ledmon.c
+++ b/src/ledmon/ledmon.c
@@ -670,6 +670,14 @@ static void _add_block(struct block_device *block)
 			} else {
 				temp->ibpi = block->ibpi;
 			}
+		} else if (temp->ibpi == LED_IBPI_PATTERN_FAILED_DRIVE &&
+			   !temp->raid_dev) {
+			/*
+			 * Non-RAID device reappeared in sysfs scan.
+			 * Allow recovery from FAILED_DRIVE so the LED
+			 * is cleared after a hot-swap cycle.
+			 */
+			temp->ibpi = LED_IBPI_PATTERN_ADDED;
 		} else if (!(temp->ibpi == LED_IBPI_PATTERN_FAILED_DRIVE &&
 			block->ibpi == LED_IBPI_PATTERN_HOTSPARE) ||
 			(temp->ibpi == LED_IBPI_PATTERN_FAILED_DRIVE &&

--- a/src/ledmon/ledmon.c
+++ b/src/ledmon/ledmon.c
@@ -671,12 +671,8 @@ static void _add_block(struct block_device *block)
 				temp->ibpi = block->ibpi;
 			}
 		} else if (temp->ibpi == LED_IBPI_PATTERN_FAILED_DRIVE &&
-			   !temp->raid_dev) {
-			/*
-			 * Non-RAID device reappeared in sysfs scan.
-			 * Allow recovery from FAILED_DRIVE so the LED
-			 * is cleared after a hot-swap cycle.
-			 */
+			   !temp->raid_dev &&
+			   !conf.blink_persistent_fail_on_readd) {
 			temp->ibpi = LED_IBPI_PATTERN_ADDED;
 		} else if (!(temp->ibpi == LED_IBPI_PATTERN_FAILED_DRIVE &&
 			block->ibpi == LED_IBPI_PATTERN_HOTSPARE) ||
@@ -892,6 +888,7 @@ static ledmon_status_code_t _init_ledmon_conf(void)
 	conf.blink_on_migration = 1;
 	conf.rebuild_blink_on_all = 0;
 	conf.raid_members_only = 0;
+	conf.blink_persistent_fail_on_readd = 1;
 	conf.scan_interval = LEDMON_DEF_SLEEP_INTERVAL;
 	return rc;
 }

--- a/src/ledmon/udev.c
+++ b/src/ledmon/udev.c
@@ -27,24 +27,40 @@ static struct udev_monitor *udev_monitor;
 
 static int _compare(const struct block_device *bd, const char *syspath, struct led_ctx *ctx)
 {
+	struct block_device *bd_new;
+	const char *udev_name;
+	const char *dev_name;
+	int ret;
+
 	if (!bd || !syspath)
 		return 0;
 
-	if (strcmp(bd->sysfs_path, syspath) == 0) {
+	if (strcmp(bd->sysfs_path, syspath) == 0)
 		return 1;
-	} else {
-		struct block_device *bd_new;
-		int ret;
 
-		bd_new = block_device_init(sysfs_get_cntrl_devices(ctx), syspath);
-		if (!bd_new)
-			return 0;
-
+	bd_new = block_device_init(sysfs_get_cntrl_devices(ctx), syspath);
+	if (bd_new) {
 		ret = block_compare(bd, bd_new);
 		block_device_fini(bd_new);
-
-		return ret;
+		if (ret)
+			return 1;
 	}
+
+	/*
+	 * NVMe udev events may arrive with a virtual nvme-subsystem path
+	 * that cannot be resolved to a PCI controller. Fall back to matching
+	 * by device name so that add/remove events are not silently dropped.
+	 */
+	if (bd->devnode[0] == '\0')
+		return 0;
+
+	dev_name = strrchr(bd->devnode, '/');
+	dev_name = dev_name ? dev_name + 1 : bd->devnode;
+
+	udev_name = strrchr(syspath, '/');
+	udev_name = udev_name ? udev_name + 1 : syspath;
+
+	return strcmp(dev_name, udev_name) == 0;
 }
 
 static int create_udev_monitor(void)

--- a/src/lib/pci_slot.c
+++ b/src/lib/pci_slot.c
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include "config.h"
 #include "led/libled.h"
@@ -71,6 +72,12 @@ struct slot_property *pci_slot_property_init(struct pci_slot *pci_slot)
 
 	result->bl_device = get_block_device_from_sysfs_path(pci_slot->ctx,
 							     pci_slot->address, true);
+	if (result->bl_device) {
+		struct stat st;
+
+		if (stat(result->bl_device->devnode, &st) != 0)
+			result->bl_device = NULL;
+	}
 	result->slot_spec.pci = pci_slot;
 	snprintf(result->slot_id, PATH_MAX, "%s", pci_slot->sysfs_path);
 	result->c = &pci_slot_common;

--- a/src/lib/tail.c
+++ b/src/lib/tail.c
@@ -14,6 +14,7 @@
 #endif
 
 #include "list.h"
+#include "sysfs.h"
 #include "tail.h"
 #include "utils.h"
 
@@ -74,6 +75,50 @@ static int _get_slot(const char *path, unsigned int *dest)
 }
 
 /**
+ * @brief Determine whether a tracked block device backs a RAID member.
+ *
+ * @param[in]  block    Block device tracked by ledmon.
+ * @param[in]  syspath  Canonicalized sysfs path of the block device backing
+ *                      the RAID member (the md .../dev-XXX/block symlink,
+ *                      resolved).
+ *
+ * Normally a member's backing device resolves to exactly the sysfs path that
+ * ledmon tracks, so a path comparison is sufficient. NVMe multipath members
+ * are the exception: they resolve to a virtual namespace-head path (e.g.
+ * /sys/devices/virtual/nvme-subsystem/nvme-subsysN/nvme2n1) while ledmon
+ * tracks the underlying per-controller device (nvme2c2n1) by its physical PCI
+ * path. Their sysfs paths differ, but both share the same /dev node, so fall
+ * back to matching on the device node. Without this fallback array-derived
+ * states (REBUILD, DEGRADED, in-array FAILURE) are never applied to multipath
+ * NVMe drives.
+ *
+ * @return true if @p block backs @p syspath, otherwise false.
+ */
+bool tail_block_matches(const struct block_device *block, const char *syspath)
+{
+	char devnode[PATH_MAX];
+	const char *name;
+	int ret;
+
+	if (strcmp(block->sysfs_path, syspath) == 0)
+		return true;
+
+	if (block->devnode[0] == '\0')
+		return false;
+
+	name = strrchr(syspath, '/');
+	name = name ? name + 1 : syspath;
+	if (name[0] == '\0')
+		return false;
+
+	ret = snprintf(devnode, sizeof(devnode), SYSTEM_DEV_DIR "/%s", name);
+	if (ret < 0 || ret >= (int)sizeof(devnode))
+		return false;
+
+	return strcmp(block->devnode, devnode) == 0;
+}
+
+/**
  */
 static struct block_device *_get_block(const char *path, struct list *block_list)
 {
@@ -99,7 +144,7 @@ static struct block_device *_get_block(const char *path, struct list *block_list
 	}
 
 	list_for_each(block_list, device) {
-		if (strcmp(device->sysfs_path, link) == 0)
+		if (tail_block_matches(device, link))
 			return device;
 	}
 	return NULL;

--- a/src/lib/tail.h
+++ b/src/lib/tail.h
@@ -27,6 +27,15 @@ struct tail_device {
 };
 
 /**
+ * @brief Determine whether a tracked block device backs a RAID member.
+ *
+ * Matches on the sysfs path, falling back to the device node so that NVMe
+ * multipath members (whose namespace-head sysfs path differs from the tracked
+ * per-controller path) are still linked to their array.
+ */
+bool tail_block_matches(const struct block_device *block, const char *syspath);
+
+/**
  */
 struct tail_device *tail_device_init(const char *path, struct list *block_list);
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,13 +3,19 @@
 
 AM_CPPFLAGS = -I@srcdir@./src/lib/include
 
-EXTRA_DIST=lib_unit_test.c
+EXTRA_DIST=lib_unit_test.c tail_match_test.c
 
 if WITH_TEST
-all: lib_unit_test
+all: lib_unit_test tail_match_test
 
-check_PROGRAMS = lib_unit_test
+check_PROGRAMS = lib_unit_test tail_match_test
 lib_unit_test_CFLAGS = $(AM_CFLAGS) $(LIBCHECK_CFLAGS)
 lib_unit_test_LDADD = ../src/lib/libled.la $(LIBCHECK_LIBS)
 lib_unit_test_SOURCES = lib_unit_test.c
+
+# tail_match_test exercises an internal (hidden-visibility) helper, so it links
+# the convenience archive rather than the public shared library.
+tail_match_test_CFLAGS = $(AM_CFLAGS) $(LIBCHECK_CFLAGS) -I$(top_srcdir)/src/lib
+tail_match_test_LDADD = ../src/lib/libledinternal.la $(LIBCHECK_LIBS)
+tail_match_test_SOURCES = tail_match_test.c
 endif

--- a/tests/tail_match_test.c
+++ b/tests/tail_match_test.c
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Red Hat, Inc.
+
+/*
+ * Unit tests for tail_block_matches(), the routine that links a RAID member's
+ * backing block device to the device ledmon tracks. The interesting case is
+ * NVMe multipath, where the member resolves to a virtual namespace-head sysfs
+ * path while ledmon tracks the per-controller device under a physical PCI path;
+ * the two are reconciled through their shared /dev node.
+ */
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <check.h>
+
+#include "block.h"
+#include "tail.h"
+
+static struct block_device make_block(const char *sysfs_path, const char *devnode)
+{
+	struct block_device bd;
+
+	memset(&bd, 0, sizeof(bd));
+	if (sysfs_path)
+		snprintf(bd.sysfs_path, PATH_MAX, "%s", sysfs_path);
+	if (devnode)
+		snprintf(bd.devnode, PATH_MAX, "%s", devnode);
+	return bd;
+}
+
+static const char nvme_mp_pci[] =
+	"/sys/devices/pci0000:d5/0000:d5:00.5/pci10003:00/10003:00:08.0/"
+	"10003:0d:00.0/nvme/nvme2/nvme2c2n1";
+static const char nvme_mp_virt[] =
+	"/sys/devices/virtual/nvme-subsystem/nvme-subsys2/nvme2n1";
+static const char sata_path[] = "/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/"
+	"target0:0:0/0:0:0:0/block/sda";
+
+struct match_case {
+	const char *desc;
+	const char *block_sysfs;
+	const char *block_devnode;
+	const char *member_syspath;
+	bool expect;
+};
+
+static const struct match_case cases[] = {
+	{
+		.desc = "exact sysfs path match (non-multipath)",
+		.block_sysfs = sata_path,
+		.block_devnode = "/dev/sda",
+		.member_syspath = sata_path,
+		.expect = true,
+	},
+	{
+		.desc = "nvme multipath: virtual head matches per-controller devnode",
+		.block_sysfs = nvme_mp_pci,
+		.block_devnode = "/dev/nvme2n1",
+		.member_syspath = nvme_mp_virt,
+		.expect = true,
+	},
+	{
+		.desc = "exact match wins even when devnode is empty",
+		.block_sysfs = nvme_mp_virt,
+		.block_devnode = "",
+		.member_syspath = nvme_mp_virt,
+		.expect = true,
+	},
+	{
+		.desc = "different namespace does not match",
+		.block_sysfs = nvme_mp_pci,
+		.block_devnode = "/dev/nvme2n1",
+		.member_syspath =
+			"/sys/devices/virtual/nvme-subsystem/nvme-subsys3/nvme3n1",
+		.expect = false,
+	},
+	{
+		.desc = "no path match and empty devnode",
+		.block_sysfs = nvme_mp_pci,
+		.block_devnode = "",
+		.member_syspath = nvme_mp_virt,
+		.expect = false,
+	},
+	{
+		.desc = "path differs and devnode differs",
+		.block_sysfs = sata_path,
+		.block_devnode = "/dev/sda",
+		.member_syspath = nvme_mp_virt,
+		.expect = false,
+	},
+	{
+		.desc = "member path with trailing slash yields no name",
+		.block_sysfs = nvme_mp_pci,
+		.block_devnode = "/dev/nvme2n1",
+		.member_syspath =
+			"/sys/devices/virtual/nvme-subsystem/nvme-subsys2/nvme2n1/",
+		.expect = false,
+	},
+};
+
+START_TEST(test_tail_block_matches)
+{
+	const struct match_case *tc = &cases[_i];
+	struct block_device bd = make_block(tc->block_sysfs, tc->block_devnode);
+	bool got = tail_block_matches(&bd, tc->member_syspath);
+
+	ck_assert_msg(got == tc->expect,
+		      "case '%s': expected %d, got %d", tc->desc, tc->expect, got);
+}
+END_TEST
+
+static Suite *tail_match_suite(void)
+{
+	Suite *s = suite_create("tail_match");
+	TCase *tc = tcase_create("tail_block_matches");
+
+	tcase_add_loop_test(tc, test_tail_block_matches, 0,
+			    (int)(sizeof(cases) / sizeof(cases[0])));
+	suite_add_tcase(s, tc);
+	return s;
+}
+
+int main(void)
+{
+	Suite *s = tail_match_suite();
+	SRunner *sr = srunner_create(s);
+
+	srunner_run_all(sr, CK_NORMAL);
+	int number_failed = srunner_ntests_failed(sr);
+
+	srunner_free(sr);
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
### Root cause

  NVMe udev events arrive with a virtual nvme-subsystem sysfs path (e.g.                                             
  `/sys/devices/virtual/nvme-subsystem/nvme-subsys1/nvme1n1`), but ledmon stores block devices using their physical
  PCI sysfs path. The `_compare()` function in udev event handling calls `block_device_init()` on the virtual path,  
  which fails because `block_get_controller()` cannot match a virtual path to any PCI controller. This silently drops
   all add and remove udev events for NVMe devices.

  Without udev event processing, ledmon detects removal only through a timestamp mismatch in `_send_msg()`, which    
  sets `FAILED_DRIVE`. On re-insertion the device reappears in the sysfs scan, but `FAILED_DRIVE` is intentionally
  sticky in `_add_block()` (to protect RAID members), so the state is never cleared. The udev `add` event that would 
  normally break out of this via the `ADDED` → `ONESHOT_NORMAL` → `UNKNOWN` state machine is never matched.

  ### Changes

  1. **Fix udev event matching** — Add a devnode name fallback to `_compare()` so that virtual nvme-subsystem paths  
  are matched to their corresponding block device.
                                                                                                                     
  2. **Allow non-RAID recovery from FAILED_DRIVE** — When a non-RAID device in `FAILED_DRIVE` state reappears in the 
  sysfs scan, transition it to `ADDED` so the state machine can drive it back to normal. RAID members remain sticky 
  and require explicit intervention regardless of whether the removal was intentional or caused by  
  hardware.   **Note: This change may need to be placed behind a configuration setting**

  3. **Validate device node in ledctl slot reporting** — Add a `stat()` check on the device node before associating a
   block device with a PCI slot, so `ledctl --list-slots` does not report a device that is no longer present.

  4. **config option**  — The previous commit unconditionally allows non-RAID devices to recover from FAILED_DRIVE state on re-add, which changes legacy behavior that some deployments may rely on (e.g. using persistent failure LEDs as an indicator that a drive misbehaved).  Add a config option to enable this new behavior.


## This needs careful review and ideally testing from user supplied issue.

Resolves: https://github.com/md-raid-utilities/ledmon/issues/274