### PR TITLE
bug: fix stuck amber LED after drive recovery on VMD controllers

### DIFF
--- a/src/ledmon/ledmon.c
+++ b/src/ledmon/ledmon.c
@@ -679,6 +679,27 @@ static void _add_block(struct block_device *block)
 
 		_handle_fail_state(block, temp);
 
+		/*
+		 * If the drive was in FAILED_DRIVE and re-appeared with UNKNOWN,
+		 * map to ONESHOT_NORMAL to actively clear the amber LED.
+		 *
+		 * Guard conditions:
+		 * - temp->ibpi == UNKNOWN: _handle_fail_state left no active state,
+		 *   meaning the drive is not an active RAID volume member (which
+		 *   would have caused _handle_fail_state to restore FAILED_DRIVE or
+		 *   set HOTSPARE).
+		 * - !block->raid_dev: the current scan sees no RAID association,
+		 *   so the drive is standalone or its array is gone. This also
+		 *   catches the OOM path in _handle_fail_state where
+		 *   raid_device_duplicate() returns NULL and the function returns
+		 *   early without clearing block->raid_dev.
+		 */
+		if (ibpi == LED_IBPI_PATTERN_FAILED_DRIVE &&
+		    block->ibpi == LED_IBPI_PATTERN_UNKNOWN &&
+		    temp->ibpi == LED_IBPI_PATTERN_UNKNOWN &&
+		    !block->raid_dev)
+			temp->ibpi = LED_IBPI_PATTERN_ONESHOT_NORMAL;
+
 		if (ibpi != temp->ibpi && ibpi <= LED_IBPI_PATTERN_REMOVED)
 			log_info("CHANGE %s: from '%s' to '%s'", temp->sysfs_path, ibpi2str(ibpi),
 				 ibpi2str(temp->ibpi));
@@ -775,15 +796,12 @@ static void _send_msg(struct block_device *block)
 		}
 	}
 
-	/**
-	 * ibpi_prev is always updated regardless send_message_fn status. It works this way from
-	 * the beginning.
-	 */
-	block->ibpi_prev = block->ibpi;
-
-	if (status)
+	if (!status) {
+		block->ibpi_prev = block->ibpi;
+	} else {
 		log_error("Unable to set %s IBPI state on %s. Status: %d",
 			  ibpi2str(block->ibpi), block->sysfs_path, status);
+	}
 }
 
 static void _flush_msg(struct block_device *block)


### PR DESCRIPTION
Two bugs in the state machine cause the failure LED to stay lit permanently after a drive is re-inserted following a FAILED_DRIVE event.

_add_block() is missing the UNKNOWN -> ONESHOT_NORMAL mapping in the FAILED_DRIVE branch. Without it, UNKNOWN reaches vmdssd_write() which rejects it (0 < NORMAL=2) and never writes ATTENTION_OFF to hardware. The mapping is applied after _handle_fail_state() with two guards: temp->ibpi == UNKNOWN (meaning _handle_fail_state left no active state; it would have set FAILED_DRIVE or HOTSPARE for active RAID members) and !block->raid_dev (the current scan sees no RAID association, which also covers the OOM path in _handle_fail_state where raid_device_duplicate() returns NULL and the function returns early without freeing block->raid_dev).

_send_msg() updated ibpi_prev unconditionally even when send_message_fn() failed. STATUS_INVALID_STATE for UNKNOWN was silently promoted to STATUS_SUCCESS, then ibpi_prev was set to UNKNOWN. The dedup guard in vmdssd_write() (ibpi == ibpi_prev) then prevented any retry, making the stuck state permanent. ibpi_prev is now only updated on success.

This also tries to address the intent of issue #235.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

This issue was originally reported in https://redhat.atlassian.net/browse/RHEL-183327