### PR TITLE
Intel references clean up

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -7,12 +7,12 @@ body:
 - type: markdown
   attributes:
     value: |
-      Before submitting a bug, please test if your issue reproduces using ledmon upstream [README](https://github.com/intel/ledmon/blob/master/README.md).
+      Before submitting a bug, please test if your issue reproduces using ledmon upstream [README](https://github.com/md-raid-utilities/ledmon/blob/master/README.md).
       It is an open-source project, so we highly encourage you to fix issue yourself
       and to become a contributor.
 
       If the issue is submitted against compilation, please double check that all
-      dependencies listed [here](https://github.com/intel/ledmon?tab=readme-ov-file#1-dependencies)
+      dependencies listed [here](https://github.com/md-raid-utilities/ledmon?tab=readme-ov-file#1-dependencies)
       are installed.
 
       Please enable highest log level when collecting logs, it could speed up investigation
@@ -63,7 +63,7 @@ body:
       Please describe your environment.
     value: |
       OS:
-      Controller Type(supported: https://github.com/intel/ledmon/blob/master/doc/ledmon.pod):
+      Controller Type(supported: https://github.com/md-raid-utilities/ledmon/blob/master/doc/ledmon.pod):
       Disks($ ls -l /sys/block):
       NVMe multipath enabled(Yes|No|N/A)($ cat /sys/module/nvme_core/parameters/multipath)?:
   validations:

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -7,12 +7,12 @@ body:
 - type: markdown
   attributes:
     value: |
-      Before submitting a bug, please test if your issue reproduces using ledmon upstream [README](https://github.com/md-raid-utilities/ledmon/blob/master/README.md).
+      Before submitting a bug, please test if your issue reproduces using ledmon upstream [README](https://github.com/md-raid-utilities/ledmon/blob/main/README.md).
       It is an open-source project, so we highly encourage you to fix issue yourself
       and to become a contributor.
 
       If the issue is submitted against compilation, please double check that all
-      dependencies listed [here](https://github.com/md-raid-utilities/ledmon?tab=readme-ov-file#1-dependencies)
+      dependencies listed [here](https://github.com/md-raid-utilities/ledmon/blob/main/README.md#1-dependencies)
       are installed.
 
       Please enable highest log level when collecting logs, it could speed up investigation

--- a/.github/workflows/nitpicker.yaml
+++ b/.github/workflows/nitpicker.yaml
@@ -4,7 +4,7 @@ permissions:
   pull-requests: write
 jobs:
   formatting-check:
-    if: github.repository == 'intel/ledmon'
+    if: github.repository == 'md-raid-utilities/ledmon'
     name: tag codeowners
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -34,8 +34,7 @@ jobs:
           *.yapf
           COPYING*
           */*.md
-          CHANGELOG.md
-          README.md
+          *.md
     - name: Run license review
       env:
         ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### v1.1.0
 
-[Commit list](https://github.com/intel/ledmon/compare/v1.0.0...v1.1.0)
+[Commit list](https://github.com/md-raid-utilities/ledmon/compare/v1.0.0...v1.1.0)
 
 Enhancements
 
@@ -18,7 +18,7 @@ Bug fixes
 
 ### v1.0.0 / 2024-02-28
 
-[Commit list](https://github.com/intel/ledmon/compare/v0.97...v1.0.0)
+[Commit list](https://github.com/md-raid-utilities/ledmon/compare/v0.97...v1.0.0)
 
 Enhancements
 
@@ -48,7 +48,7 @@ Bug fixes
 
 ### v0.97 / 2023-05-16
 
-[Commit list](https://github.com/intel/ledmon/compare/v0.96...v0.97)
+[Commit list](https://github.com/md-raid-utilities/ledmon/compare/v0.96...v0.97)
 
 Enhancements
 
@@ -74,7 +74,7 @@ Bug fixes
 
 ### v0.96 / 2022-05-26
 
-[Commit list](https://github.com/intel/ledmon/compare/v0.95...v0.96)
+[Commit list](https://github.com/md-raid-utilities/ledmon/compare/v0.95...v0.96)
 
 Bug fixes
 
@@ -88,7 +88,7 @@ Bug fixes
 
 ### v0.95 / 2021-01-15
 
-[Commit list](https://github.com/intel/ledmon/compare/v0.94...v0.95)
+[Commit list](https://github.com/md-raid-utilities/ledmon/compare/v0.94...v0.95)
 
 Enhancements
 
@@ -111,7 +111,7 @@ Bug fixes
 
 ### v0.94 / 2020-02-04
 
-[Commit list](https://github.com/intel/ledmon/compare/v0.93...v0.94)
+[Commit list](https://github.com/md-raid-utilities/ledmon/compare/v0.93...v0.94)
 
 Enhancements
 
@@ -127,7 +127,7 @@ Bug fixes
 
 ### v0.93 / 2019-10-17
 
-[Commit list](https://github.com/intel/ledmon/compare/v0.92...v0.93)
+[Commit list](https://github.com/md-raid-utilities/ledmon/compare/v0.92...v0.93)
 
 Enhancements
 
@@ -146,7 +146,7 @@ Bug fixes
 
 ### v0.92 / 2019-04-12
 
-[Commit list](https://github.com/intel/ledmon/compare/v0.91-fixed...v0.92)
+[Commit list](https://github.com/md-raid-utilities/ledmon/compare/v0.91-fixed...v0.92)
 
 Bug fixes
 * Silence warning and error messages.
@@ -154,7 +154,7 @@ Bug fixes
 
 ### v0.91 / 2019-04-01
 
-[Commit list](https://github.com/intel/ledmon/compare/v0.90...v0.91)
+[Commit list](https://github.com/md-raid-utilities/ledmon/compare/v0.90...v0.91)
 
 Enhancements
 
@@ -181,7 +181,7 @@ Bug fixes
 
 ### v0.90 / 2018-02-14
 
-[Commit list](https://github.com/intel/ledmon/compare/v0.80...v0.90)
+[Commit list](https://github.com/md-raid-utilities/ledmon/compare/v0.80...v0.90)
 
 Enhancements
 
@@ -202,7 +202,7 @@ Bug fixes
 
 ### v0.80 / 2016-10-28
 
-[Commit list](https://github.com/intel/ledmon/compare/v0.70...v0.80)
+[Commit list](https://github.com/md-raid-utilities/ledmon/compare/v0.70...v0.80)
 
 Enhancements
 
@@ -221,7 +221,7 @@ Bug fixes
 
 ### v0.70 / 2012-12-12
 
-[Commit list](https://github.com/intel/ledmon/compare/v0.40...v0.70)
+[Commit list](https://github.com/md-raid-utilities/ledmon/compare/v0.40...v0.70)
 
 Enhancements
 
@@ -235,7 +235,7 @@ Bug fixes
 
 ### v0.40 / 2012-07-12
 
-[Commit list](https://github.com/intel/ledmon/compare/v0.3...v0.40)
+[Commit list](https://github.com/md-raid-utilities/ledmon/compare/v0.3...v0.40)
 
 Enhancements
 
@@ -249,7 +249,7 @@ Bug fixes
 
 ### v0.3 / 2012-03-06
 
-[Commit list](https://github.com/intel/ledmon/compare/v0.2...v0.3)
+[Commit list](https://github.com/md-raid-utilities/ledmon/compare/v0.2...v0.3)
 
 Enhancements
 
@@ -262,7 +262,7 @@ Removals
 
 ### v0.2 / 2011-08-24
 
-[Commit list](https://github.com/intel/ledmon/compare/af8f20626e4e36cdf4bb9955fc65f22fec155580...v0.2)
+[Commit list](https://github.com/md-raid-utilities/ledmon/compare/af8f20626e4e36cdf4bb9955fc65f22fec155580...v0.2)
 
 Enhancements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Header and Copyrights
 
 Verification of License and Copyrights is automated on Github by
-[Licensing test](https://github.com/intel/ledmon/blob/main/tests/licensing.py).
+[Licensing test](https://github.com/md-raid-utilities/ledmon/blob/main/tests/licensing.py).
 
 The rules for Licenses and Copyrights are as follows:
 - Preferred comment mark should be used for file type. Please prefer to test or other files for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Header and Copyrights
 
-Verification of License and Copyrights is automated on Github by
+Verification of License and Copyrights is automated on GitHub by
 [Licensing test](https://github.com/md-raid-utilities/ledmon/blob/main/tests/licensing.py).
 
 The rules for Licenses and Copyrights are as follows:

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
-# This package contains the Enclosure LED Utilities, version 1.1.0
+# Enclosure LED Utilities
 
-Copyright (C) 2009-2024 Intel Corporation.
+Current version is 1.1.0.
 
-Files in this package can be freely distributed and used according
-to the terms of the GNU General Public License, version 2 or the
-GNU Lesser General Public License version 2.1 or later depending on file.
+Enclosure LED Utilities is a Linux project for monitoring and controlling storage device LEDs
+on platforms. It enables visual identification and status indication (locate, fault, rebuild, etc.) for drives in enclosures and backplanes.
 
-See http://www.gnu.org/ for details.
+For more details and list of supported LED control protocols, refer to `ledmon(8)` man page.
+
+The project provides following tools:
+- **`ledmon`** — a daemon that monitors md RAID array and automatically updates drive LEDs to reflect array status.
+- **`ledctl`** — a command-line tool for manually setting LED states on specific storage devices.
+- **`libled`** — a shared library that exposes LED control functionality for integration into
+  third-party applications.
 
 -------------------------
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Security Policy
+
+This is community-maintained project. We take security issues seriously
+and appreciate coordinated disclosure from researchers and users.
+
+## Supported Versions
+
+Security fixes are provided for the latest released version on the `main`
+branch. Older versions are not maintained; please retest on the latest `main`
+before reporting.
+
+Depending on the problem urgency, other more problem-driven action would be taken.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+pull requests, or discussions.** Public disclosure before a fix is available
+puts users at risk.
+
+Instead, use one of the following private channels:
+
+1. **GitHub Private Vulnerability Reporting (preferred).**
+   Navigate to the repository's
+   [Security tab](https://github.com/md-raid-utilities/ledmon/security) and
+   click **Report a vulnerability**. This opens a private advisory visible only
+   to the reporter and the maintainers. See GitHub's guide on
+   [privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+   for details.
+
+2. **Email the maintainers.**
+   If you cannot use GitHub's private reporting, send an encrypted or plain
+   email to `mtkaczyk@kernel.org` and `tasleson@redhat.com`.
+
+### What to include
+
+To help us triage quickly, please include as much of the following as you can:
+
+- A description of the issue and its impact.
+- The affected component (`ledmon`, `ledctl`, `libled`) and version or commit.
+- Steps to reproduce, a proof-of-concept, or a crash/backtrace.
+- Any known mitigations or workarounds.
+- Whether you intend to request a CVE.
+- How you would like to be credited (or if you prefer to remain anonymous).
+
+## Coordinated Disclosure
+
+Our process is:
+
+1. **Acknowledgment.** We aim to acknowledge new reports within a few business
+   days. Because this is a volunteer-maintained project we cannot guarantee a
+   strict SLA, but we will keep you informed of progress.
+2. **Triage and fix.** We work with the reporter to confirm the issue, assess
+   severity, and develop a fix in a private branch or GitHub security advisory.
+3. **Embargo.** Please give us a reasonable time to prepare a fix and, where
+   appropriate, to coordinate with Linux distributions before public
+   disclosure. A typical embargo window is up to 90 days, shorter for
+   already-public or actively-exploited issues.
+4. **Release and advisory.** Once a fix is ready we publish a new release, a
+   GitHub Security Advisory, and (when applicable) request a CVE. Reporters are
+   credited unless they ask otherwise.

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 # Copyright (C) 2009 Intel Corporation.
 
-# Intel(R) Enclosure LED Utilities
+# Enclosure LED Utilities
 
 CLEANFILES = ledmon.conf.gz ledmon.gz ledctl.gz
 EXTRA_DIST = ledmon.conf.pod ledmon.pod ledctl.pod
@@ -11,12 +11,12 @@ dist_man8_MANS = ledmon.gz ledctl.gz
 
 ledmon.conf.gz: ledmon.conf.pod
 	pod2man -r "LEDMON.CONF Version $(PACKAGE_VERSION) $(BUILD_LABEL)" -d "@PACKAGE_DATE@" \
-		-s 5 -n ledmon.conf -c "Intel(R) Enclosure LED Utilities Config" $< | gzip -9f > $@
+		-s 5 -n ledmon.conf -c "Enclosure LED Utilities Config" $< | gzip -9f > $@
 
 ledmon.gz: ledmon.pod
 	pod2man -r "LEDMON Version $(PACKAGE_VERSION) $(BUILD_LABEL)" -d "@PACKAGE_DATE@" \
-		-s 8 -n ledmon -c "Intel(R) Enclosure LED Monitor Service" $< | gzip -9f > $@
+		-s 8 -n ledmon -c "Enclosure LED Monitor Service" $< | gzip -9f > $@
 
 ledctl.gz: ledctl.pod
 	pod2man -r "LEDCTL Version $(PACKAGE_VERSION) $(BUILD_LABEL)" -d "@PACKAGE_DATE@" \
-		-s 8 -n ledctl -c "Intel(R) Enclosure LED Control Application" $< | gzip -9f > $@
+		-s 8 -n ledctl -c "Enclosure LED Control Application" $< | gzip -9f > $@

--- a/doc/ledctl.pod
+++ b/doc/ledctl.pod
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: GPL-2.0-only
 # Copyright (C) 2009 Intel Corporation.
 
-# Intel(R) Enclosure LED Utilities
+# Enclosure LED Utilities
 
 =head1 NAME
 
-ledctl - Intel(R) LED control application for a storage enclosures.
+ledctl - LED control application for storage enclosures.
 
 =head1 SYNOPSIS
 
@@ -59,7 +59,7 @@ The ledmon application has the highest priority when accessing LEDs.
 Meaning that some patterns set by ledctl may have no effect if ledmon is running
 (exception: Locate pattern).
 
-The ledctl application is a part of Intel(R) Enclosure LED Utilities.
+The ledctl application is a part of Enclosure LED Utilities.
 
 =head4 The ledctl utilizes the following documents as references:
 
@@ -96,9 +96,7 @@ NPEM (Native PCIe Enclosure Management) - PCIe base specification rev 4.0
 
 =item
 
-VMD (Intel(R) Volume Management Device) - Intel(R) VROC (VMD NVMe RAID) Quick
-
-Configuration Guide rev 1.2
+VMD (Intel(R) Volume Management Device)
 
 =back
 

--- a/doc/ledmon.conf.pod
+++ b/doc/ledmon.conf.pod
@@ -1,16 +1,16 @@
 # SPDX-License-Identifier: GPL-2.0-only
 # Copyright (C) 2009 Intel Corporation.
 
-# Intel(R) Enclosure LED Utilities
+# Enclosure LED Utilities
 
 =head1 NAME
 
-ledmon.conf - Configuration file for Intel(R) Enclosure LED Utilities.
+ledmon.conf - Configuration file for Enclosure LED Utilities.
 
 =head1 DESCRIPTION
 
 The ledmon configuration file allows you to use advanced settings and functions
-of the Intel(R) Enclosure LED Utilities. The global location of the configuration
+of the Enclosure LED Utilities. The global location of the configuration
 file is F</etc/ledmon.conf>. Instead of a global configuration file, you can
 specify a local config file using the I<-c> option when running ledmon.
 

--- a/doc/ledmon.pod
+++ b/doc/ledmon.pod
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: GPL-2.0-only
 # Copyright (C) 2009 Intel Corporation.
 
-# Intel(R) Enclosure LED Utilities
+# Enclosure LED Utilities
 
 =head1 NAME
 
-ledmon - Intel(R) LED monitor service for storage enclosures.
+ledmon - LED monitor service for storage enclosures.
 
 =head1 SYNOPSIS
 
@@ -105,8 +105,7 @@ NPEM (Native PCIe Enclosure Management) - PCIe base specification rev 4.0
 
 =item
 
-VMD (Intel(R) Volume Management Device) - Intel(R) VROC (VMD NVMe RAID) Quick
-Configuration Guide rev 1.2
+VMD (Intel(R) Volume Management Device)
 
 =back
 

--- a/security.md
+++ b/security.md
@@ -1,5 +1,0 @@
-# Security Policy
-Intel is committed to rapidly addressing security vulnerabilities affecting our customers and providing clear guidance on the solution, impact, severity and mitigation. 
-
-## Reporting a Vulnerability
-Please report any security vulnerabilities in this project [utilizing the guidelines here](https://www.intel.com/content/www/us/en/security-center/vulnerability-handling-guidelines.html).

--- a/src/ledctl/help.c
+++ b/src/ledctl/help.c
@@ -141,7 +141,7 @@ static struct help_mode modes[] = {
  */
 void _ledctl_version(void)
 {
-	printf("Intel(R) Enclosure LED Control Application %s %s\n"
+	printf("Enclosure LED Control Application %s %s\n"
 	       "Copyright (C) 2009-2024 Intel Corporation.\n\n", PACKAGE_VERSION, BUILD_LABEL);
 }
 

--- a/src/ledctl/help.c
+++ b/src/ledctl/help.c
@@ -153,7 +153,7 @@ void _ledctl_version(void)
 static void print_ledctl_help_footer(void)
 {
 	printf("\nRefer to ledctl(8) man page for more detailed description (man ledctl).\n");
-	printf("Bugs should be reported at: https://github.com/intel/ledmon/issues\n");
+	printf("Bugs should be reported at: https://github.com/md-raid-utilities/ledmon/issues\n");
 }
 
 void _print_incorrect_help_usage(void)

--- a/src/ledmon/ledmon.c
+++ b/src/ledmon/ledmon.c
@@ -265,7 +265,7 @@ static void _ledmon_help(void)
 	print_opt("--version", "-v",
 			  "Displays version and license information.");
 	printf("\nRefer to ledmon(8) man page for more detailed description.\n");
-	printf("Bugs should be reported at: https://github.com/intel/ledmon/issues\n");
+	printf("Bugs should be reported at: https://github.com/md-raid-utilities/ledmon/issues\n");
 }
 
 /**

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 # Copyright (C) 2009 Intel Corporation.
 
-# Intel(R) Enclosure LED Utilities
+# Enclosure LED Utilities
 
 SUBDIRS = include
 

--- a/src/lib/sysfs.h
+++ b/src/lib/sysfs.h
@@ -35,7 +35,7 @@ struct sysfs {
 	/**
 	 * This is internal variable global to sysfs module only. It is a list of
 	 * storage controller devices registered in the system and
-	 * supported by Intel(R) Enclosure LEDs Control Utility. Use sysfs_init()
+	 * supported by Enclosure LEDs Control Utility. Use sysfs_init()
 	 * function to initialize the variable. Use sysfs_scan() function to populate
 	 * the list. Use sysfs_reset() function to delete the content of the list.
 	 */

--- a/tests/ledctl/parameters_test.py
+++ b/tests/ledctl/parameters_test.py
@@ -135,7 +135,7 @@ def parse_help(lines):
 
     help_footer = [
         "Refer to ledctl(8) man page for more detailed description (man ledctl).",
-        "Bugs should be reported at: https://github.com/intel/ledmon/issues"
+        "Bugs should be reported at: https://github.com/md-raid-utilities/ledmon/issues"
     ]
 
     assert (next(line_inter) == help_footer[0])

--- a/tests/ledctl/parameters_test.py
+++ b/tests/ledctl/parameters_test.py
@@ -94,7 +94,7 @@ def test_parameter_log_level_all_values(ledctl_binary):
 
 def parse_version(lines):
     help_header = [
-        "Intel(R) Enclosure LED Control Application",
+        "Enclosure LED Control Application",
         "Copyright (C) 2009-2024 Intel Corporation."
     ]
 


### PR DESCRIPTION
Intel leaves this behind and it is owned by community now so it is right time to remove Intel references from documentation, manuals and helps.

This is not attempting to remove Intel copyright which of course are still honored as they should be!

README is separate case as it is not holding any IP that can be copyrighted and we have regular COPYING file but I'm wrong then please speak-up loudly.

Still in progress.